### PR TITLE
ci: only run this pipeline on relevant pull requests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ on:
     branches:
     - main
     paths:
-    - ".github/workflows/integration.yaml"
+    - ".github/workflows/integration.yml"
     - "!(**/*.md)"
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
     - main
+    paths:
+    - ".github/workflows/integration.yaml"
+    - "!(**/*.md)"
 
 jobs:
   compute_matrix:


### PR DESCRIPTION
@vinai and I were stuck waiting for
https://github.com/mage-os/infrastructure/pull/22 to merge which was completely irrelevant to the work at hand