### PR TITLE
fix: do not use GITHUB_* as it is reserved

### DIFF
--- a/.github/workflows/merge-upstream-changes.yml
+++ b/.github/workflows/merge-upstream-changes.yml
@@ -12,7 +12,7 @@ on:
     secrets:
       DISCORD_WEBHOOK:
         required: true
-      GITHUB_TOKEN:
+      MAGEOS_GITHUB_TOKEN:
         required: true
 
 jobs:
@@ -62,7 +62,7 @@ jobs:
           git push origin ${{ matrix.branch }}
           git push --delete origin ${{ matrix.branch }}-upstream || true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MAGEOS_GITHUB_TOKEN }}
 
       # If the merge failed, checkout the upstream branch and push it to our repo.
       - name: Create Upstream Branch
@@ -74,7 +74,7 @@ jobs:
           git push --set-upstream --force origin ${{ matrix.branch }}-upstream
           git remote remove upstream
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MAGEOS_GITHUB_TOKEN }}
 
       # If the merge failed, and we successfully created an upstream branch, create a pull request.
       - name: Create Pull Request
@@ -85,7 +85,7 @@ jobs:
           draft: true
           title: "Upstream Merge Conflict (${{ matrix.branch }})"
           body: "This PR was automatically generated: a human is required.\n\n${{ steps.merge.outputs.merge }}"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.MAGEOS_GITHUB_TOKEN }}
           source_branch: ${{ matrix.branch }}-upstream
           target_branch: ${{ matrix.branch }}
 


### PR DESCRIPTION
Invalid workflow file: .github/workflows/merge-upstream-changes.yml#L10
error parsing called workflow "mage-os/infrastructure/.github/workflows/merge-upstream-changes.yml@main": secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name