### PR TITLE
chore: fix commit of discord-action for security

### DIFF
--- a/.github/workflows/merge-upstream-changes.yml
+++ b/.github/workflows/merge-upstream-changes.yml
@@ -93,7 +93,7 @@ jobs:
       # If the merge failed, and we successfully created a PR, send a message to discord.
       - name: Notify Discord
         if: failure() && steps.merge.outcome == 'failure' && steps.create_pr.outcome == 'success'
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@08d9328877d6954120eef2b07abbc79249bb6210
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: "Mage-OS"


### PR DESCRIPTION
The workflow has full write access, using `@master` seems a bit risky.