### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/.github/workflows/merge-upstream-changes.yml
+++ b/.github/workflows/merge-upstream-changes.yml
@@ -53,7 +53,7 @@ jobs:
           git fetch upstream ${{ matrix.branch }}
           git merge --no-edit FETCH_HEAD 2>&1 | tee merge.log
           result_code=${PIPESTATUS[0]}
-          echo "::set-output name=merge::$(cat merge.log)"
+          echo "merge=$(cat merge.log)" >> $GITHUB_OUTPUT
           exit $result_code
 
       # When merge succeeds, simply push to the original branch.


### PR DESCRIPTION
https://github.com/mage-os/mageos-magento2/actions/runs/6942520648 shows warning:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Even though the deprecation date has been moved, I think it makes sense to replace the command.

Mind that this is untested, because I am honestly not sure how to properly test it.